### PR TITLE
Remove duplicative PHPFINFO conditional block.

### DIFF
--- a/inc/php_configure.inc
+++ b/inc/php_configure.inc
@@ -70,13 +70,6 @@ else
 	SNMPOPT=""
 fi
 
-if [ "$PHPFINFO" == 'y' ]; then
-	FILEINFOOPT=""
-else
-	FILEINFOOPT=" --disable-fileinfo"
-fi
-
-
 if [[ "$CHECKLOWMEMPHP" = "1" || "$PHPFINFO" = 'n' ]]; then
         FILEINFOOPT=" --disable-fileinfo"
 else


### PR DESCRIPTION
The PHPFINFO variable was being checked, then checked again along with the CHECKLOWMEMPHP variable. You really only need the second conditional block.