### PR TITLE
Missing slash in the path of included file in /tools/nginxupdate.sh file, line 383

### DIFF
--- a/tools/nginxupdate.sh
+++ b/tools/nginxupdate.sh
@@ -380,7 +380,7 @@ fi
 
 ###################################################################################
 # source file dependencies for variables
-source "${SCRIPT_DIR}inc/fastmirrors.conf"
+source "${SCRIPT_DIR}/inc/fastmirrors.conf"
 source "${SCRIPT_DIR}/inc/customrpms.inc"
 source "${SCRIPT_DIR}/inc/pureftpd.inc"
 source "${SCRIPT_DIR}/inc/htpasswdsh.inc"


### PR DESCRIPTION
Fixes #70 
There is a missing slash in the path of included file (an argument of the "source" command) in /tools/nginxupdate.sh file.