### PR TITLE
Makes expressions in if-statements simpler and easier to understand. Fixes some bugs.

### DIFF
--- a/centmin.sh
+++ b/centmin.sh
@@ -958,7 +958,7 @@ if [ ! -f /usr/bin/sar ]; then
     systemctl restart sysstat.service
     systemctl enable sysstat.service
   fi
-elif [ -f /usr/bin/sar ]; then
+else
   if [[ "$(uname -m)" = 'x86_64' ]]; then
     SARCALL='/usr/lib64/sa/sa1'
   else
@@ -1602,24 +1602,12 @@ PHPMVER=$(echo "$PHP_VERSION" | cut -d . -f1,2)
 
 # ZOPCACHE_OVERRIDE=y allows you to override PHP 5.5-7.0's inbuilt included
 # Zend Opcache version with one available from pecl site
-if [[ "$ZOPCACHE_OVERRIDE" = [yY] && "$ZOPCACHEDFT" = [yY] ]] && [[ "$PHPMVER" = '5.4' || "$PHPMVER" = '5.5' || "$PHPMVER" = '5.6' || "$PHPMVER" = '5.7' || "$PHPMVER" = '7.0' || "$PHPMVER" = '7.1' ]]; then
-    zopcacheinstall
+if [[ "$ZOPCACHEDFT" = [yY] ]] && [[ "$PHPMVER" = 5.[234] || "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
+	zopcacheinstall
 fi
 
-if [[ "$ZOPCACHEDFT" = [yY] && "$PHPMVER" = '5.4' ]]; then
-    zopcacheinstall
-fi
-
-if [[ "$ZOPCACHEDFT" = [yY] && "$PHPMVER" = '5.3' ]]; then
-    zopcacheinstall
-fi
-
-if [[ "$ZOPCACHEDFT" = [yY] && "$PHPMVER" = '5.2' ]]; then
-    zopcacheinstall
-fi
-
-# if PHP_VERSION = 5.5, 5.6 or 5.7 will need to setup a zendopcache.ini settings file
-if [[ "$ZOPCACHE_OVERRIDE" != [yY] ]] && [[ "$APCINSTALL" = [nN] || "$ZOPCACHEDFT" = [yY] ]] && [[ "$PHPMVER" = '5.5' || "$PHPMVER" = '5.6' || "$PHPMVER" = '5.7' || "$PHPMVER" = '7.0' ]]; then
+# if PHP_VERSION = 5.5 or newer will need to setup a zendopcache.ini settings file
+if [[ "$PHPMVER" > 5.4 && "$ZOPCACHE_OVERRIDE" != [yY] ]] && [[ "$APCINSTALL" = [nN] || "$ZOPCACHEDFT" = [yY] ]]; then
 	zopcache_initialini
 fi
 
@@ -1803,7 +1791,7 @@ fi
 funct_centos6check() {
 
 
-if [[ "$CENTOSVER" == '5.6' || "$CENTOSVER" == '5.7'|| "$CENTOSVER" == '5.8' || "$CENTOSVER" == '5.9' || "$CENTOSVER" == '5.10' || "$CENTOSVER" == '5.11' || "$CENTOSVER" == '6.0' || "$CENTOSVER" == '6.1' || "$CENTOSVER" == '6.2' || "$CENTOSVER" = '6.3' || "$CENTOSVER" = '6.4' || "$CENTOSVER" = '6.5' || "$CENTOSVER" = '6.6' || "$CENTOSVER" = '6.7' || "$CENTOSVER" = '6.8' || "$CENTOSVER" = '6.9' || "$CENTOSVER" = '7.0' || "$CENTOSVER" = '7.1' || "$CENTOSVER" = '7.2' || "$CENTOSVER" = '7.3' || "$CENTOSVER" = '7.4' || "$CENTOSVER" = '7.5' || "$CENTOSVER" = '7.6' || "$CENTOSVER" = '7.7' ]]; then
+if [[ "$CENTOSVER" > 5.5 ]]; then
 
 MCRYPT=" --with-mcrypt"
 

--- a/inc/apcinstall.inc
+++ b/inc/apcinstall.inc
@@ -43,10 +43,10 @@ fi
 
 if [[ "$PHPCURRENTVER" = '5.5' ]]; then
     apcdevfix
-elif [[ "$PHPCURRENTVER" = '5.2' || "$PHPCURRENTVER" = '5.3' || "$PHPCURRENTVER" = '5.4' ]]; then
+elif [[ "$PHPCURRENTVER" = 5.[234] ]]; then
     #tar xvzf APC-${APCCACHE_VERSION}.tgz
     cd APC-${APCCACHE_VERSION}
-elif [[ "$PHPCURRENTVER" = '5.6' || "$PHPCURRENTVER" = '5.7' || "$PHPCURRENTVER" = '7.0' ]]; then
+elif [[ "$PHPCURRENTVER" > 5.5 ]]; then
     echo "Your current PHP $PHPCURRENTVER version is not supported. Use Zend Opcache instead"
     if [[ "$INITIALINSTALL" != [yY] ]]; then
         exit

--- a/inc/memcached_install.inc
+++ b/inc/memcached_install.inc
@@ -411,7 +411,7 @@ php -v | awk -F " " '{print $2}' | head -n1 | cut -d . -f1,2 | egrep '7.0|7.1'
 PHPSEVEN_CHECKVER=$?
 echo "$PHPSEVEN_CHECKVER"
 
-if [[ "$PHPMUVER" = '7.0' || "$PHPMUVER" = 'NGDEBUG' || "$PHPSEVEN_CHECKVER" = '0' ]]; then
+if [[ "$PHPMUVER" > 7 || "$PHPSEVEN_CHECKVER" = '0' ]]; then
     echo
     echo "compiling memcached PHP extension for PHP 7.x ..."
     rm -rf memcached-php7

--- a/inc/php_configure.inc
+++ b/inc/php_configure.inc
@@ -413,7 +413,7 @@ if [[ "$GCCINTEL_PHP" = [yY] ]]; then
     fi
   fi
   # php upgrades
-  if [[ "$PHP_PGO_CENTOSSIX" = [yY] ]] && [[ "$PHP_PGO" = [yY] ]] && [[ "$PHPMUVER" = '7.0' || "$PHPMUVER" = '7.1' || "$PHPMUVER" = '7.2' ]]; then
+  if [[ "$PHP_PGO_CENTOSSIX" = [yY] && "$PHP_PGO" = [yY] && "$PHPMUVER" > 7 ]]; then
     if [[ "$CENTOS_SIX" = '6' ]]; then
       if [[ ! -f /opt/rh/devtoolset-4/root/usr/bin/gcc || ! -f /opt/rh/devtoolset-4/root/usr/bin/g++ ]] || [[ ! -f /opt/rh/devtoolset-6/root/usr/bin/gcc || ! -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
         scl_install
@@ -447,7 +447,7 @@ if [[ "$GCCINTEL_PHP" = [yY] ]]; then
   fi
   # CentOS 7 use devtoolset-4 GCC 5.2 if it's detected
   # initial php install
-  if [[ "$CENTOS_SEVEN" = '7' ]] && [[ "$PHP_PGO" = [yY] ]] && [[ "$PHPMVER" = '7.0' || "$PHPMVER" = '7.1' ]]; then
+  if [[ "$CENTOS_SEVEN" = '7' && "$PHP_PGO" = [yY] && "$PHPMVER" > 7 ]]; then
     # if devtoolset-4 gcc and g++ exist use then instead of system versions regardless of CentOS version
     if [[ "$DEVTOOLSETSIX" = [yY] && -f /opt/rh/devtoolset-6/root/usr/bin/gcc && -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
         source /opt/rh/devtoolset-6/enable
@@ -474,7 +474,7 @@ if [[ "$GCCINTEL_PHP" = [yY] ]]; then
     fi
   fi
   # php upgrades
-  if [[ "$CENTOS_SEVEN" = '7' ]] && [[ "$PHP_PGO" = [yY] ]] && [[ "$PHPMUVER" = '7.0' || "$PHPMUVER" = '7.1' || "$PHPMUVER" = '7.2' ]]; then
+  if [[ "$CENTOS_SEVEN" = '7' && "$PHP_PGO" = [yY] && "$PHPMUVER" > 7 ]]; then
     # if devtoolset-4 gcc and g++ exist use then instead of system versions regardless of CentOS version
     if [[ "$DEVTOOLSETSIX" = [yY] && -f /opt/rh/devtoolset-6/root/usr/bin/gcc && -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
         source /opt/rh/devtoolset-6/enable
@@ -599,9 +599,9 @@ if [[ "$GCCINTEL_PHP" = [yY] ]]; then
 fi
 
 # zend opcache hugepages
-if [[ "$PHPMUVER" = '7.0' || "$PHPMUVER" = '7.1' || "$PHPMUVER" = '7.2' ]]; then
+if [[ "$PHPMUVER" > 7 ]]; then
 	opcachehugepages
-elif [[ "$PHPMUVER" != '7.0' ]]; then	
+else
 	if [ -f "${CONFIGSCANDIR}/zendopcache.ini" ]; then
 		if [[ "$(grep 'opcache.huge_code_pages' ${CONFIGSCANDIR}/zendopcache.ini)" ]]; then
 			sed -i 's|^opcache.huge_code_pages=1|;opcache.huge_code_pages=0|' ${CONFIGSCANDIR}/zendopcache.ini

--- a/inc/php_upgrade.inc
+++ b/inc/php_upgrade.inc
@@ -315,7 +315,7 @@ fi
 
     phpgeolocation
 
-if [[ "$PHPMUVER" != '5.5' || "$PHPMUVER" != '5.6' || "$PHPMUVER" != '5.7' || "$PHPMUVER" != '7.0' || "$PHPMUVER" != '7.1' ]]; then
+if [[ "$PHPMUVER" = 5.[234] ]]; then
     PHPEXTSION='gz'
     PHPTAR_FLAGS='xzf'
 fi

--- a/inc/zendopcache_55ini.inc
+++ b/inc/zendopcache_55ini.inc
@@ -3,7 +3,7 @@ zopcache_initialini() {
 	if [[ "$PHP_INSTALL" = [yY] ]]; then
 PHPMVER=$(echo "$PHP_VERSION" | cut -d . -f1,2)
 
-if [[ "$PHPMVER" = '5.5' || "$PHPMVER" = '5.6' || "$PHPMVER" = '5.7' || "$PHPMVER" = '7.0' ]]; then
+if [[ "$PHPMVER" > 5.4 ]]; then
 	PHPEXTDIRD=`cat /usr/local/bin/php-config | awk '/^extension_dir/ {extdir=$1} END {gsub(/\047|extension_dir|=|)/,"",extdir); print extdir}'`
 fi # PHPMVER
 

--- a/inc/zendopcache_reinstall.inc
+++ b/inc/zendopcache_reinstall.inc
@@ -41,13 +41,13 @@ echo "-------------------------------------------------------------------"
 
 
 # only prompt for Zend Opcache version if PHP version is between 5.2 and 5.4 inclusive
-if [[ "$(expr $PHPMVER \>= 5.2)" = 1 && "$(expr $PHPMVER \<= 5.4)" = 1 ]] && [[ "$(expr $PHPCURRENTVER \>= 5.2)" = 1 && "$(expr $PHPCURRENTVER \<= 5.4)" = 1 ]]; then
+if [[ "$PHPMVER" = 5.[234] && "$PHPCURRENTVER" = 5.[234] ]]; then
 	ZOPCACHEPROMPT='y'
 # prompt if ZOPCACHE_OVERRIDE=y for PHP versions between 5.5-5.6
-elif [[ "$(expr $PHPMVER \>= 5.5)" = 1 && "$(expr $PHPMVER \<= 5.6)" = 1 && "$ZOPCACHE_OVERRIDE" = [yY] ]] && [[ "$(expr $PHPCURRENTVER \>= 5.5)" = 1 && "$(expr $PHPCURRENTVER \<= 5.6)" = 1 && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
+elif [[ "$PHPMVER" = 5.[56] && "$PHPCURRENTVER" = 5.[56] && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
 	ZOPCACHEPROMPT='y'
 # prompt if ZOPCACHE_OVERRIDE=y for PHP version 7.0	
-elif [[ "$(expr $PHPMVER \= 7.0)" = 1 && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
+elif [[ "$PHPMVER" > 7 && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
 	ZOPCACHEPROMPT='y'	
 else
 	ZOPCACHEPROMPT='n'
@@ -55,13 +55,13 @@ fi
 
 # check if this is a PHP upgrade task
 if [ "$PHPMUVER" ]; then
-	if [[ "$(expr $PHPMUVER \>= 5.2)" = 1 && "$(expr $PHPMUVER \<= 5.4)" = 1 ]]; then
+	if [[ "$PHPMUVER" = 5.[234] ]]; then
 		ZOPCACHEPROMPT='y'
 	# prompt if ZOPCACHE_OVERRIDE=y for PHP versions between 5.5-5.6
-	elif [[ "$(expr $PHPMUVER \>= 5.5)" = 1 && "$(expr $PHPMUVER \<= 5.6)" = 1 && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
+	elif [[ "$PHPMUVER" = 5.[56] && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
 		ZOPCACHEPROMPT='y'
 	# prompt if ZOPCACHE_OVERRIDE=y for PHP version 7.0		
-	elif [[ "$(expr $PHPMUVER \= 7.0)" = 1 && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
+	elif [[ "$PHPMUVER" > 7 && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
 		ZOPCACHEPROMPT='y'		
 	else
 		ZOPCACHEPROMPT='n'

--- a/inc/zendopcache_upgrade.inc
+++ b/inc/zendopcache_upgrade.inc
@@ -75,7 +75,7 @@ cmservice nginx reload
 #################
 zopcacheupgrade() {
 	if [[ "$PHP_INSTALL" = [yY] ]]; then
-if [[ "$PHPMUVER" = '5.5' || "$PHPMUVER" = '5.6' || "$PHPMUVER" = '5.7' || "$PHPMUVER" = '7.0' || "$PHPMUVER" = '7.1' || "$PHPMUVER" = '7.2' || "$PHPMUVER" = 'NGDEBUG' ]]; then
+if [[ "$PHPMUVER" > 5.5 ]]; then
 	echo ""
 	echo "-----------------------------------------------------------------------------------------"
 	cecho "Detected PHP $PHPMUVER branch." $boldyellow


### PR DESCRIPTION
Bugs:
* file inc\zendopcache_reinstall.inc, line 50 - missing '>' after '/'
* file centmin.sh, line 1605 - unnecessary checking for "$PHPMVER" = '5.4'
* file inc/php_upgrade.inc, line 318 - logical expression in the if-statement is always 'true' regardless of the value of PHPMUVER