### PR TITLE
Fixes bugs in some if-statement expressions and makes them simpler

### DIFF
--- a/inc/php_upgrade.inc
+++ b/inc/php_upgrade.inc
@@ -149,15 +149,12 @@ if [[ "$DETECTMONGODB" = [yY] ]] || [[ "$DETECTMONGODB" = [yY] && ! -f "$PHPEXTD
 fi
 
 if [[ "$DETECTOPCACHE" = [yY] ]]; then
-    if [[ "$PHPMUVER" != '5.5' || "$PHPMUVER" != '5.6' || "$PHPMUVER" != '5.7' || "$PHPMUVER" != '7.0' || "$PHPMUVER" != '7.1' ]]; then
-        cecho "Auto reinstalling previously detected Zend Opcache" $boldyellow
-        zopcachereinstall
-    elif [[ "$PHPMUVER" = '5.5' || "$PHPMUVER" = '5.6' || "$PHPMUVER" = '5.7' || "$PHPMUVER" = '7.0' || "$PHPMUVER" = '7.1' ]] && [[ "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
-        # ZOPCACHE_OVERRIDE=y allows you to override PHP 5.5-7.0's inbuilt included
-        # Zend Opcache version with one available from pecl site
-        cecho "Auto reinstalling previously detected Zend Opcache" $boldyellow
-        zopcachereinstall        
-    fi
+	# ZOPCACHE_OVERRIDE=y allows you to override PHP 5.5-7.x's inbuilt included
+	# Zend Opcache version with one available from pecl site
+	if [[ "$PHPMUVER" = 5.[234] || "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
+		cecho "Auto reinstalling previously detected Zend Opcache" $boldyellow
+		zopcachereinstall
+	fi
 fi
 
 if [[ "$DETECTMAILPARSE" = [yY] ]] || [[ "$DETECTMAILPARSE" = [yY] && ! -f "$PHPEXTDIR_AUTODETECT/mailparse.so" ]]; then

--- a/inc/zendopcache_install.inc
+++ b/inc/zendopcache_install.inc
@@ -90,7 +90,7 @@ echo "Current centmin.sh set PHP_VERSION: $PHPMVER"
 echo "Current PHP upgrade version set: $PHPMUVER"
 echo "-------------------------------------------------------------------"
 
-if [[ "$ZOPCACHE_OVERRIDE" = [yY] || "$PHPMVER" != '7.0' || "$PHPCURRENTVER" != '7.0' || "$PHPMVER" != '5.7' || "$PHPCURRENTVER" != '5.7' || "$PHPMVER" != '5.6' || "$PHPCURRENTVER" != '5.6' || "$PHPMVER" != '5.5' || "$PHPCURRENTVER" != '5.5' || "$PHPMVER" = '5.4' ||"$PHPMVER" = '5.3' ||"$PHPMVER" = '5.2' ]]; then
+if [[ "$PHPCURRENTVER" == 5.[2-4] || "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
 
 	if [[ ! -d "${DIR_TMP}/zendopcache-${ZOPCACHECACHE_VERSION}" || ! -f "${DIR_TMP}/${ZENDOPCACHE_LINKFILE}" ]]; then
 		zopcachetarball
@@ -199,6 +199,6 @@ else
 	echo "Detected PHP branch: 5.5+ which has native support for Zend OPcache"
 	echo "To enable Zend OPcache run menu option #5 and specify PHP 5.5.0 or higher"
 
-fi # check for PHPMVER !=5.5
+fi # check for PHPCURRENTVER
 	fi # PHP_INSTALL=y
 }

--- a/inc/zendopcache_reinstall.inc
+++ b/inc/zendopcache_reinstall.inc
@@ -39,32 +39,19 @@ echo "Current PHP upgrade version set: $PHPMUVER"
 echo "-------------------------------------------------------------------"
 
 
+ZOPCACHEPROMPT='n'
 
-# only prompt for Zend Opcache version if PHP version is between 5.2 and 5.4 inclusive
-if [[ "$PHPMVER" = 5.[234] && "$PHPCURRENTVER" = 5.[234] ]]; then
-	ZOPCACHEPROMPT='y'
-# prompt if ZOPCACHE_OVERRIDE=y for PHP versions between 5.5-5.6
-elif [[ "$PHPMVER" = 5.[56] && "$PHPCURRENTVER" = 5.[56] && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
-	ZOPCACHEPROMPT='y'
-# prompt if ZOPCACHE_OVERRIDE=y for PHP version 7.0	
-elif [[ "$PHPMVER" > 7 && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
-	ZOPCACHEPROMPT='y'	
-else
-	ZOPCACHEPROMPT='n'
-fi
+# prompt for Zend Opcache version if PHP version is 5.2-5.4 or if ZOPCACHE_OVERRIDE=y for PHP versions 5.5 and higher
 
-# check if this is a PHP upgrade task
 if [ "$PHPMUVER" ]; then
-	if [[ "$PHPMUVER" = 5.[234] ]]; then
+# run if this is a PHP upgrade task
+	if [[ "$PHPMUVER" = 5.[234] || "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
 		ZOPCACHEPROMPT='y'
-	# prompt if ZOPCACHE_OVERRIDE=y for PHP versions between 5.5-5.6
-	elif [[ "$PHPMUVER" = 5.[56] && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
+	fi
+else
+# run from Zend Opcache sub menu
+	if [[ "$PHPCURRENTVER" = 5.[234] || "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
 		ZOPCACHEPROMPT='y'
-	# prompt if ZOPCACHE_OVERRIDE=y for PHP version 7.0		
-	elif [[ "$PHPMUVER" > 7 && "$ZOPCACHE_OVERRIDE" = [yY] ]]; then
-		ZOPCACHEPROMPT='y'		
-	else
-		ZOPCACHEPROMPT='n'
 	fi
 fi
 

--- a/inc/zendopcache_submenu.inc
+++ b/inc/zendopcache_submenu.inc
@@ -12,8 +12,8 @@ do
 	cecho "--------------------------------------------------------" $boldyellow
 	cecho "        Zend OpCache Sub-Menu              " $boldgreen
 	cecho "--------------------------------------------------------" $boldyellow
-	cecho "1). Install Zend OpCache for PHP <5.5 or <5.6" $boldgreen
-	cecho "2). Reinstall Zend OpCache for PHP <5.5 or <5.6" $boldgreen
+	cecho "1). Install Zend OpCache" $boldgreen
+	cecho "2). Reinstall Zend OpCache" $boldgreen
 	cecho "3). Back to Main menu" $boldgreen
 	cecho "--------------------------------------------------------" $boldyellow
 


### PR DESCRIPTION
* file inc\php_upgrade.inc, line 152
An expression in the if-statement is always 'true'.

* file inc\zendopcache_install.inc, line 93
An expression in the if-statement is always 'true'.
It's not necessary to check PHPCURRENTVER together with PHPMVER. PHPMVER is based on PHP_VERSION from config file. But PHPCURRENTVER is real version of PHP installed on a machine.

* file inc\zendopcache_reinstall.inc, lines 44, 47, 50
It's not necessary to check PHPCURRENTVER together with PHPMVER. PHPMVER is based on PHP_VERSION from config file. But PHPCURRENTVER is real version of PHP installed on a machine.

* inc\zendopcache_submenu.inc, lines 15-16
changes comments: it is not necessary to mention any PHP version here