### PR TITLE
Change hardcoded version of nginx-accesskey module to master branch.

### DIFF
--- a/inc/downloadlinks.inc
+++ b/inc/downloadlinks.inc
@@ -195,8 +195,8 @@ NGX_FANCYINDEXLINK="${LOCALCENTMINMOD_MIRROR}/centminmodparts/nginx/modules/${NG
 NGX_CACHEPURGEFILE="ngx_cache_purge-${NGINX_CACHEPURGEVER}.tar.gz"
 NGX_CACHEPURGE="${LOCALCENTMINMOD_MIRROR}/centminmodparts/nginx/modules/${NGX_CACHEPURGEFILE}"
 
-NGX_ACCESSKEYLINKFILE="Nginx-accesskey-2.0.3.tar.gz"
-NGX_ACCESSKEYLINK="${LOCALCENTMINMOD_MIRROR}/centminmodparts/nginx/modules/${NGX_ACCESSKEYLINKFILE}"
+NGX_ACCESSKEYLINKFILE="nginx-accesskey-master.tar.gz"
+NGX_ACCESSKEYLINK="https://github.com/Martchus/nginx-accesskey/archive/master.tar.gz"
 
 # wget renamed
 NGX_CONCATLINKFILE="nginx-http-concat-master.tar.gz"

--- a/inc/nginx_configure.inc
+++ b/inc/nginx_configure.inc
@@ -482,7 +482,7 @@ if [[ "$CENTOS_SEVEN" = '7' || "$CENTOS_SIX" = '6' ]]; then
 	fi
 
 	if [[ "$NGINX_ACCESSKEY" = [yY] ]]; then
-		ACCESSKEYOPT=" --add-module=../nginx-accesskey-2.0.3"
+		ACCESSKEYOPT=" --add-module=../nginx-accesskey-master"
 	else
 		ACCESSKEYOPT=""
 	fi		


### PR DESCRIPTION
nginx-accesskey hardcoded version is 2.0.3 but the latest one is 2.0.4.
It is better to download master branch. So that it is no need to track version changes.
Now nginx-accesskey is downloaded from master branch.