### PR TITLE
Remove unnecessary call to pcredir_check() function

### DIFF
--- a/inc/nginx_install.inc
+++ b/inc/nginx_install.inc
@@ -175,8 +175,6 @@ then
 
 fi # GPERFTOOLS_SOURCE INSTALL
 
-pcredir_check
-
 installopenssl
 
     if [ -f "$(which figlet)" ]; then


### PR DESCRIPTION
pcredir_check() function checks for ${PCRELINKFILE} file presence but it always exists in that moment because of calling inside nginxtarball() function.
The chain is alldownloads() -> nginxtarball() -> ngxmoduletarball() -> nginxpcretarball()