### PR TITLE
Fix missing 'make' for lua-redis-parser module.

### DIFF
--- a/inc/nginx_configure.inc
+++ b/inc/nginx_configure.inc
@@ -902,7 +902,7 @@ if [[ "$CENTOS_SEVEN" = '7' || "$CENTOS_SIX" = '6' ]]; then
     	cd "${DIR_TMP}/$NGX_LUAWEBSOCKETDIR"; make clean; make install; mv /usr/local/lib/lua/resty/websocket/* /usr/local/lib/lua/resty/; rm -rf /usr/local/lib/lua/resty/websocket
     	cd "${DIR_TMP}/$NGX_LUALOCKDIR"; make clean; make install
     	cd "${DIR_TMP}/$NGX_LUASTRINGDIR"; make clean; make install
-    	cd "${DIR_TMP}/$NGX_LUAREDISPARSERDIR"; make clean; make install; mv /usr/local/lib/lua/resty/redis/* /usr/local/lib/lua/resty/; rm -rf /usr/local/lib/lua/resty/redis
+    	cd "${DIR_TMP}/$NGX_LUAREDISPARSERDIR"; make clean; make; make install;
     	cd "${DIR_TMP}/$NGX_LUAUPSTREAMCHECKDIR"; make clean; make install; mv /usr/local/lib/lua/resty/upstream/* /usr/local/lib/lua/resty/; rm -rf /usr/local/lib/lua/resty/upstream
     	cd "${DIR_TMP}/$NGX_LUALRUCACHEDIR"; make clean; make install; mv /usr/local/lib/lua/resty/lrucache/* /usr/local/lib/lua/resty/; rm -rf /usr/local/lib/lua/resty/lrucache
     	cd "${DIR_TMP}/$NGX_LUARESTYCOREDIR"; make clean; make install; mv /usr/local/lib/lua/resty/core/* /usr/local/lib/lua/resty/; rm -rf /usr/local/lib/lua/resty/core


### PR DESCRIPTION
Otherwise 'make install' shows an error message about missing parcer.so file.