### PR TITLE
Improve enable_devtoolset() function. Add enable_clang() function.

### DIFF
--- a/inc/gcc.inc
+++ b/inc/gcc.inc
@@ -1,4 +1,4 @@
-function enable_clang() {
+enable_clang() {
    if [[ "$CENTOS_SIX" = 6 || "$CENTOS_SEVEN" = 7 ]] && [[ ! -f /usr/bin/clang ]]; then
       time $YUMDNFBIN -q -y install clang clang-devel${DISABLEREPO_DNF}
    fi
@@ -15,7 +15,7 @@ function enable_clang() {
 }
 
 
-function enable_devtoolset() {
+enable_devtoolset() {
    # ccache compiler has some initial overhead for compiles but speeds up subsequent
    # recompiles. however on initial install ccache has no benefits, so for initial
    # centmin mod install disabling ccache will in theory speed up first time installs
@@ -77,7 +77,7 @@ function enable_devtoolset() {
    fi
 }
 
-function disable_devtoolset() {
+disable_devtoolset() {
   if [[ "$GENERAL_DEVTOOLSETGCC" = [yY] ]]; then
     if [[ "$(uname -m)" == 'x86_64' && $(grep Intel /proc/cpuinfo) ]]; then
         echo "$CFLAGS"
@@ -93,7 +93,7 @@ function disable_devtoolset() {
   fi
 }
 
-function set_intelflags() {
+set_intelflags() {
 	if [[ "$INTELOPT" = [yY] ]]; then
     	if [[ "$(uname -m)" == 'x86_64' && $(grep Intel /proc/cpuinfo) ]]; then
         	CFLAGS='-O2 -m64 -march=native -pipe -g -mmmx -msse3'
@@ -109,7 +109,7 @@ function set_intelflags() {
 	fi
 }
 
-function unset_intelflags() {
+unset_intelflags() {
 	if [[ "$INTELOPT" = [yY] ]]; then
     	if [[ "$(uname -m)" == 'x86_64' && $(grep Intel /proc/cpuinfo) ]]; then
         	unset CFLAGS
@@ -123,7 +123,7 @@ function unset_intelflags() {
 
 
 # function currently disabled not ready for use
-function checkgcc() {
+checkgcc() {
 
 if [[ "$INTELOPT" = [yY] ]]; then
 	NGINX_GCCOPT='y'

--- a/inc/gcc.inc
+++ b/inc/gcc.inc
@@ -1,158 +1,83 @@
-enable_devtoolset() {
-# devtoolset-4 usage for ngx_pagespeed 1.10 branch which doesn't support
-# centos 6 based gcc 4.4.7
-if [[ "$CENTOS_SIX" = '6' && "$GENERAL_DEVTOOLSETGCC" = [yY] ]]; then
-  if [[ ! -f /opt/rh/devtoolset-4/root/usr/bin/gcc || ! -f /opt/rh/devtoolset-4/root/usr/bin/g++ ]] || [[ ! -f /opt/rh/devtoolset-6/root/usr/bin/gcc || ! -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
-    scl_install
-    if [[ "$INITIALINSTALL" != [yY] ]]; then
-      source /opt/rh/devtoolset-4/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="ccache gcc"
-      export CXX="ccache g++"
-    else
-      source /opt/rh/devtoolset-4/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="gcc"
-      export CXX="g++"
-    fi
-  elif [[ "$DEVTOOLSETSIX" = [yY] && -f /opt/rh/devtoolset-6/root/usr/bin/gcc && -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
-    # update devtoolset-6 repo
-    # place holder if need to update devtoolset-6 in future
-    if [[ "$INITIALINSTALL" != [yY] ]]; then
-      source /opt/rh/devtoolset-6/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="ccache gcc"
-      export CXX="ccache g++"
-    else
-      source /opt/rh/devtoolset-6/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="gcc"
-      export CXX="g++"
-    fi
-  elif [[ -f /opt/rh/devtoolset-4/root/usr/bin/gcc && -f /opt/rh/devtoolset-4/root/usr/bin/g++ ]]; then
-    # update devtoolset-4 repo
-    # place holder if need to update devtoolset-4 in future
-    if [[ "$INITIALINSTALL" != [yY] ]]; then
-      source /opt/rh/devtoolset-4/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="ccache gcc"
-      export CXX="ccache g++"
-    else
-      source /opt/rh/devtoolset-4/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="gcc"
-      export CXX="g++"
-    fi
-  fi
-fi
-
-# devtoolset-4 usage of GCC 4.9 even for CentOS7
-if [[ "$CENTOS_SEVEN" = '7' && "$GENERAL_DEVTOOLSETGCC" = [yY] ]]; then
-  if [[ ! -f /opt/rh/devtoolset-4/root/usr/bin/gcc || ! -f /opt/rh/devtoolset-4/root/usr/bin/g++ ]] || [[ ! -f /opt/rh/devtoolset-6/root/usr/bin/gcc || ! -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
-    scl_install
-    if [[ "$INITIALINSTALL" != [yY] ]]; then
-      if [[ "$DEVTOOLSETSIX" = [yY] && -f /opt/rh/devtoolset-6/root/usr/bin/gcc && -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
-        source /opt/rh/devtoolset-6/enable
-      elif [[ -f /opt/rh/devtoolset-4/root/usr/bin/gcc && -f /opt/rh/devtoolset-4/root/usr/bin/g++ ]]; then
-        source /opt/rh/devtoolset-4/enable
-      fi
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="ccache gcc"
-      export CXX="ccache g++"
-    else
-      if [[ "$DEVTOOLSETSIX" = [yY] && -f /opt/rh/devtoolset-6/root/usr/bin/gcc && -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
-        source /opt/rh/devtoolset-6/enable
-      elif [[ -f /opt/rh/devtoolset-4/root/usr/bin/gcc && -f /opt/rh/devtoolset-4/root/usr/bin/g++ ]]; then
-        source /opt/rh/devtoolset-4/enable
-      fi
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="gcc"
-      export CXX="g++"
-    fi
-  elif [[ "$DEVTOOLSETSIX" = [yY] && -f /opt/rh/devtoolset-6/root/usr/bin/gcc && -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
-    if [[ "$INITIALINSTALL" != [yY] ]]; then
-      source /opt/rh/devtoolset-6/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="ccache gcc"
-      export CXX="ccache g++"
-    else
-      source /opt/rh/devtoolset-6/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="gcc"
-      export CXX="g++"
-    fi
-  elif [[ -f /opt/rh/devtoolset-4/root/usr/bin/gcc && -f /opt/rh/devtoolset-4/root/usr/bin/g++ ]]; then
-    if [[ "$INITIALINSTALL" != [yY] ]]; then
-      source /opt/rh/devtoolset-4/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="ccache gcc"
-      export CXX="ccache g++"
-    else
-      source /opt/rh/devtoolset-4/enable
-      which gcc
-      which g++
-      unset CC
-      unset CXX
-      export CC="gcc"
-      export CXX="g++"
-    fi
-  fi
-fi
-
-if [[ "$GENERAL_DEVTOOLSETGCC" = [yY] ]]; then
-  # intel specific
-  CPUVENDOR=$(cat /proc/cpuinfo | awk '/vendor_id/ {print $3}' | sort -u | head -n1)
-  SSECHECK=$(gcc -c -Q -march=native --help=target | awk '/  -msse/ {print $2}' | head -n1)
-  gcc --version | tee ${CENTMINLOGDIR}/gcc_general_native.log
-  gcc -c -Q -march=native --help=target | egrep '\[enabled\]|mtune|march|mfpmath' | tee -a ${CENTMINLOGDIR}/gcc_general_native.log
-  if [[ "$(uname -m)" = 'x86_64' && "$CPUVENDOR" = 'GenuineIntel' && "$SSECHECK" = '[enabled]' ]]; then
-      CCM=64
-      GEN_MTUNEOPT="-m${CCM} -march=native"
-      # if only 1 cpu thread use -O2 to keep compile times sane
-      if [[ "$CPUS" = '1' ]]; then
-        export CFLAGS="-O2 $GEN_MTUNEOPT -pipe"
-      else
-        export CFLAGS="-O3 $GEN_MTUNEOPT -pipe"
-      fi
-      export CXXFLAGS="$CFLAGS"
-  fi
-fi
+function enable_clang() {
+   if [[ "$CENTOS_SIX" = 6 || "$CENTOS_SEVEN" = 7 ]] && [[ ! -f /usr/bin/clang ]]; then
+      time $YUMDNFBIN -q -y install clang clang-devel${DISABLEREPO_DNF}
+   fi
+   if [[ "$INITIALINSTALL" != [yY] ]]; then             
+      export CC="ccache /usr/bin/clang -ferror-limit=0"
+      export CXX="ccache /usr/bin/clang++ -ferror-limit=0"
+      export CCACHE_CPP2=yes
+   else
+      export CC="/usr/bin/clang -ferror-limit=0"
+      export CXX="/usr/bin/clang++ -ferror-limit=0"
+   fi
+   CLANG_CFLAGOPT='-Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-const-variable -Wno-conditional-uninitialized -Wno-mismatched-tags -Wno-sometimes-uninitialized -Wno-parentheses-equality -Wno-tautological-compare -Wno-self-assign -Wno-deprecated-register -Wno-deprecated -Wno-invalid-source-encoding -Wno-pointer-sign -Wno-parentheses -Wno-enum-conversion -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-undefined-inline -Wno-unused-function -Wno-int-conversion -Wno-implicit-function-declaration -Wno-non-literal-null-conversion'
+   export CFLAGS="$CLANG_CFLAGOPT"
 }
 
-disable_devtoolset() {
+
+function enable_devtoolset() {
+   # ccache compiler has some initial overhead for compiles but speeds up subsequent
+   # recompiles. however on initial install ccache has no benefits, so for initial
+   # centmin mod install disabling ccache will in theory speed up first time installs
+   if [[ "$INITIALINSTALL" != [yY] ]]; then            
+      export CC="ccache /usr/bin/gcc"
+      export CXX="ccache /usr/bin/g++"
+      export CCACHE_CPP2=yes
+   else
+      export CC="/usr/bin/gcc"
+      export CXX="/usr/bin/g++"
+   fi
+   CLANG_CFLAGOPT=""
+   CFLAGS=""
+
+   if [[ "$GENERAL_DEVTOOLSETGCC" = [yY] ]]; then
+      # devtoolset-4 usage for ngx_pagespeed 1.10 branch which doesn't support
+      # centos 6 based gcc 4.4.7
+      if [[ "$CENTOS_SIX" = 6 || "$CENTOS_SEVEN" = 7 ]]; then
+         if [[ "$DEVTOOLSETSIX" = [yY] ]]; then
+            if [[ ! -f /opt/rh/devtoolset-6/root/usr/bin/gcc || ! -f /opt/rh/devtoolset-6/root/usr/bin/g++ ]]; then
+               scl_install
+            fi       
+            source /opt/rh/devtoolset-6/enable
+         else
+            if [[ ! -f /opt/rh/devtoolset-4/root/usr/bin/gcc || ! -f /opt/rh/devtoolset-4/root/usr/bin/g++ ]]; then
+               scl_install
+            fi
+            source /opt/rh/devtoolset-4/enable
+         fi
+         which gcc
+         which g++
+         unset CC
+         unset CXX
+         if [[ "$INITIALINSTALL" != [yY] ]]; then
+            export CC="ccache gcc"
+            export CXX="ccache g++"
+         else
+            export CC="gcc"
+            export CXX="g++"
+         fi
+      fi
+
+      # intel specific
+      CPUVENDOR=$(cat /proc/cpuinfo | awk '/vendor_id/ {print $3}' | sort -u | head -n1)
+      SSECHECK=$(gcc -c -Q -march=native --help=target | awk '/  -msse/ {print $2}' | head -n1)
+      gcc --version | tee ${CENTMINLOGDIR}/gcc_general_native.log
+      gcc -c -Q -march=native --help=target | egrep '\[enabled\]|mtune|march|mfpmath' | tee -a ${CENTMINLOGDIR}/gcc_general_native.log
+      if [[ "$(uname -m)" = 'x86_64' && "$CPUVENDOR" = 'GenuineIntel' && "$SSECHECK" = '[enabled]' ]]; then
+         CCM=64
+         GEN_MTUNEOPT="-m${CCM} -march=native"
+         # if only 1 cpu thread use -O2 to keep compile times sane
+         if [[ "$CPUS" = '1' ]]; then
+            export CFLAGS="-O2 $GEN_MTUNEOPT -pipe"
+         else
+            export CFLAGS="-O3 $GEN_MTUNEOPT -pipe"
+         fi
+         export CXXFLAGS="$CFLAGS"
+      fi
+   fi
+}
+
+function disable_devtoolset() {
   if [[ "$GENERAL_DEVTOOLSETGCC" = [yY] ]]; then
     if [[ "$(uname -m)" == 'x86_64' && $(grep Intel /proc/cpuinfo) ]]; then
         echo "$CFLAGS"
@@ -168,7 +93,7 @@ disable_devtoolset() {
   fi
 }
 
-set_intelflags() {
+function set_intelflags() {
 	if [[ "$INTELOPT" = [yY] ]]; then
     	if [[ "$(uname -m)" == 'x86_64' && $(grep Intel /proc/cpuinfo) ]]; then
         	CFLAGS='-O2 -m64 -march=native -pipe -g -mmmx -msse3'
@@ -184,7 +109,7 @@ set_intelflags() {
 	fi
 }
 
-unset_intelflags() {
+function unset_intelflags() {
 	if [[ "$INTELOPT" = [yY] ]]; then
     	if [[ "$(uname -m)" == 'x86_64' && $(grep Intel /proc/cpuinfo) ]]; then
         	unset CFLAGS
@@ -198,7 +123,7 @@ unset_intelflags() {
 
 
 # function currently disabled not ready for use
-checkgcc() {
+function checkgcc() {
 
 if [[ "$INTELOPT" = [yY] ]]; then
 	NGINX_GCCOPT='y'

--- a/inc/memcached_install.inc
+++ b/inc/memcached_install.inc
@@ -85,46 +85,11 @@ checkigbinary() {
 
 #######################################################
 function funct_memcachedreinstall {
-
-        if [[ "$CLANG_MEMCACHED" = [yY] ]]; then
-            if [[ "$CENTOS_SIX" = '6' && ! -f /usr/bin/clang ]] || [[ "$CENTOS_SEVEN" = '7' && ! -f /bin/clang ]]; then
-                time $YUMDNFBIN -q -y install clang clang-devel${DISABLEREPO_DNF}
-            fi
-            # ccache compiler has some initial overhead for compiles but speeds up subsequent
-            # recompiles. however on initial install ccache has no benefits, so for initial
-            # centmin mod install disabling ccache will in theory speed up first time installs
-            if [[ "$INITIALINSTALL" != [yY] ]]; then             
-                export CC="ccache /usr/bin/clang -ferror-limit=0"
-                export CXX="ccache /usr/bin/clang++ -ferror-limit=0"
-                export CCACHE_CPP2=yes
-                CLANG_CFLAGOPT='-Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-const-variable -Wno-conditional-uninitialized -Wno-mismatched-tags -Wno-sometimes-uninitialized -Wno-parentheses-equality -Wno-tautological-compare -Wno-self-assign -Wno-deprecated-register -Wno-deprecated -Wno-invalid-source-encoding -Wno-pointer-sign -Wno-parentheses -Wno-enum-conversion -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-undefined-inline -Wno-unused-function -Wno-int-conversion -Wno-implicit-function-declaration -Wno-non-literal-null-conversion'
-                export CFLAGS="$CLANG_CFLAGOPT"
-            else
-                export CC="/usr/bin/clang -ferror-limit=0"
-                export CXX="/usr/bin/clang++ -ferror-limit=0"
-                # export CCACHE_CPP2=yes
-                CLANG_CFLAGOPT='-Wno-deprecated-declarations -Wno-unused-parameter -Wno-unused-const-variable -Wno-conditional-uninitialized -Wno-mismatched-tags -Wno-sometimes-uninitialized -Wno-parentheses-equality -Wno-tautological-compare -Wno-self-assign -Wno-deprecated-register -Wno-deprecated -Wno-invalid-source-encoding -Wno-pointer-sign -Wno-parentheses -Wno-enum-conversion -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-undefined-inline -Wno-unused-function -Wno-int-conversion -Wno-implicit-function-declaration -Wno-non-literal-null-conversion'
-                export CFLAGS="$CLANG_CFLAGOPT"
-            fi                
-        else
-            # ccache compiler has some initial overhead for compiles but speeds up subsequent
-            # recompiles. however on initial install ccache has no benefits, so for initial
-            # centmin mod install disabling ccache will in theory speed up first time installs
-            if [[ "$INITIALINSTALL" != [yY] ]]; then            
-                export CC="ccache /usr/bin/gcc"
-                export CXX="ccache /usr/bin/g++"
-                export CCACHE_CPP2=yes
-                CLANG_CFLAGOPT=""
-                CFLAGS=""
-            else
-                export CC="/usr/bin/gcc"
-                export CXX="/usr/bin/g++"
-                # export CCACHE_CPP2=yes
-                CLANG_CFLAGOPT=""
-                CFLAGS=""
-            fi
-            enable_devtoolset
-        fi       
+   if [[ "$CLANG_MEMCACHED" = [yY] ]]; then
+      enable_clang
+   else
+      enable_devtoolset
+   fi
 
 PHPEXTDIRD=$(cat /usr/local/bin/php-config | awk '/^extension_dir/ {extdir=$1} END {gsub(/\047|extension_dir|=|)/,"",extdir); print extdir}')
 

--- a/inc/memcached_install.inc
+++ b/inc/memcached_install.inc
@@ -84,7 +84,7 @@ checkigbinary() {
 }
 
 #######################################################
-function funct_memcachedreinstall {
+funct_memcachedreinstall {
    if [[ "$CLANG_MEMCACHED" = [yY] ]]; then
       enable_clang
    else


### PR DESCRIPTION
Make enable_devtoolset() function simpler.
Add enable_clang() function. It could be use in somebody's addons to make code smaller.
For example:
if [[ "$CLANG" = [yY] ]]; then
   enable_clang
else
   enable_devtoolset
fi

I use it in my own addon.