### PR TITLE
Set nginx user for logrotate

### DIFF
--- a/logrotate/nginx
+++ b/logrotate/nginx
@@ -2,6 +2,7 @@
 # nano -w /etc/logrotate.d/nginx
 
 /var/log/nginx/*.log /usr/local/nginx/logs/*.log /home/nginx/domains/*/log/*.log {
+        su nginx nginx
         daily
         missingok
         rotate 10


### PR DESCRIPTION
I'd been getting loads of cron error emails from logrotate about skipped files due to permissions. This config change fixes that.

Something should probably be done to apply this change when centime.sh is next run...