### PR TITLE
Use the special mask “msie6”

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -102,7 +102,7 @@ error_log   logs/error.log warn;
 
 	gzip on;
 	gzip_vary   on;
-	gzip_disable "MSIE [1-6]\.";
+	gzip_disable msie6;
         gzip_static on;
         gzip_min_length   1400;
         gzip_buffers      1024 8k;


### PR DESCRIPTION
More Info: http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_disable

The special mask “msie6” (0.7.12) corresponds to the regular expression “MSIE [4-6]\.”, but works faster. Starting from version 0.8.11, “MSIE 6.0; ... SV1” is excluded from this mask.