### PR TITLE
retry downloading wp core incase it fails.

### DIFF
--- a/inc/wpsetup.inc
+++ b/inc/wpsetup.inc
@@ -2288,7 +2288,12 @@ if [[ -d "/home/nginx/domains/${vhostname}/public" ]]; then
 
 cd /home/nginx/domains/${vhostname}/public${WPSUBDIR}
  
-\wp core download --allow-root
+n=0
+until [ "$n" -ge 10 ]
+do
+   \wp core download --allow-root && break
+   n=$((n+1)) 
+done
  
 \wp core config --dbname=$DB --dbuser=$DBUSER --dbpass=$DBPASS --allow-root
  


### PR DESCRIPTION
Past couple days wordpress.org has been having issues

Error: Failed to get url 'https://downloads.wordpress.org/release/wordpress-5.4.1.tar.gz.md5': cURL error 28: Connection timed out after 10001 milliseconds.

Retrying the download a few times should help.