### PR TITLE
Enable brotli by just uncommenting a line

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -62,6 +62,7 @@ include /usr/local/nginx/conf/ssl_include.conf;
 include /usr/local/nginx/conf/pagespeedadmin.conf;
 include /usr/local/nginx/conf/fastcgi_param_https_map.conf;
 include /usr/local/nginx/conf/default_phpupstream.conf;
+#include /usr/local/nginx/conf/brotli_inc.conf;
 
 log_format  main  '$remote_addr - $remote_user [$time_local] $request '
                 '"$status" $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
This would be useful to enable brotli when available by just uncommenting the line #include /usr/local/nginx/conf/brotli_inc.conf;