### PR TITLE
Update csfinstall.inc to include access to external MySQL instances

### DIFF
--- a/inc/csfinstall.inc
+++ b/inc/csfinstall.inc
@@ -179,7 +179,7 @@ if [[ "$CSFINSTALLOK" = [yY] ]]; then
     echo "CSF adding memcached, varnish ports to csf.allow list..."
     sed -i 's/20,21,22,25,53,80,110,143,443,465,587,993,995/20,21,22,25,53,80,110,111,143,161,443,465,587,993,995,1110,1186,1194,2049,81,9418,30001:50011/g' /etc/csf/csf.conf
 
-sed -i "s/TCP_OUT = \"/TCP_OUT = \"8080,2525,465,111,2049,1110,1194,9418,/g" /etc/csf/csf.conf
+sed -i "s/TCP_OUT = \"/TCP_OUT = \"8080,2525,465,111,2049,1110,1194,9418,3306,/g" /etc/csf/csf.conf
 sed -i "s/TCP6_OUT = \"/TCP6_OUT = \"8080,2525,465,/g" /etc/csf/csf.conf
 sed -i "s/UDP_IN = \"/UDP_IN = \"67,68,111,2049,1110,33434:33534,/g" /etc/csf/csf.conf
 sed -i "s/UDP_OUT = \"/UDP_OUT = \"67,68,111,2049,1110,33434:33534,/g" /etc/csf/csf.conf


### PR DESCRIPTION
I *constantly* forget that MySQL ports are not whitelisted and I end up spending too much time figuring out what is wrong. =)